### PR TITLE
Extend MIDI note status to fix note releases

### DIFF
--- a/quantum/process_keycode/process_midi.c
+++ b/quantum/process_keycode/process_midi.c
@@ -34,7 +34,7 @@ void process_midi_all_notes_off(void) { midi_send_cc(&midi_device, 0, 0x7B, 0); 
 
 #        include "timer.h"
 
-static uint8_t tone_status[MIDI_TONE_COUNT];
+static uint8_t tone_status[2][MIDI_TONE_COUNT];
 
 static uint8_t  midi_modulation;
 static int8_t   midi_modulation_step;
@@ -51,7 +51,8 @@ void midi_init(void) {
     midi_config.modulation_interval = 8;
 
     for (uint8_t i = 0; i < MIDI_TONE_COUNT; i++) {
-        tone_status[i] = 0;
+        tone_status[0][i] = MIDI_INVALID_NOTE;
+        tone_status[1][i] = 0;
     }
 
     midi_modulation       = 0;
@@ -71,13 +72,17 @@ bool process_midi(uint16_t keycode, keyrecord_t *record) {
                 uint8_t note = midi_compute_note(keycode);
                 midi_send_noteon(&midi_device, channel, note, velocity);
                 dprintf("midi noteon channel:%d note:%d velocity:%d\n", channel, note, velocity);
-                tone_status[tone] += 1;
+                tone_status[1][tone] += 1;
+                if (tone_status[0][tone] == MIDI_INVALID_NOTE) {
+                    tone_status[0][tone] = note;
+                }
             } else {
-                tone_status[tone] -= 1;
-                if (tone_status[tone] == 0) {
-                    uint8_t note = midi_compute_note(keycode);
+                uint8_t note = tone_status[0][tone];
+                tone_status[1][tone] -= 1;
+                if (tone_status[1][tone] == 0) {
                     midi_send_noteoff(&midi_device, channel, note, velocity);
                     dprintf("midi noteoff channel:%d note:%d velocity:%d\n", channel, note, velocity);
+                    tone_status[0][tone] = MIDI_INVALID_NOTE;
                 }
             }
             return false;


### PR DESCRIPTION
Extends the current implementation instead of rewriting it unneccesarily. The already existing `tone_status` array now keeps track of what notes have been pressed and how many times they have been pressed, and MIDI note off messages are only sent when the number of times a note has been released is the same as the number of times it has been pressed. This fixes the original issue of notes being cut short when they are triggered by different keys, and the issue I accidentally added where notes wouldn't be released if an octave shift or transpose happened between pressing a note and releasing it.